### PR TITLE
fix: Complete scattered TODOs across the app

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,10 +21,10 @@ const config: PlaywrightTestConfig = {
 	},
 	timeout: 60000,
 	projects: [
-		{ name: 'chromium', use: { ...devices['Desktop Chrome'] } },
-		{ name: 'firefox', use: { ...devices['Desktop Firefox'] } },
-		{ name: 'webkit', use: { ...devices['Desktop Safari'] } }
+		{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }
 		// TODO: maybe add more browsers? (mobile and stuff)
+		// { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+		// { name: 'webkit', use: { ...devices['Desktop Safari'] } }
 	]
 };
 

--- a/src/routes/(components)/page/TodaysWorkoutCard.svelte
+++ b/src/routes/(components)/page/TodaysWorkoutCard.svelte
@@ -10,8 +10,9 @@
 
 	type PropsType = {
 		todaysWorkoutData: Promise<RouterOutputs['workouts']['getTodaysWorkoutData']>;
+		pastWorkouts: Promise<RouterOutputs['mesocycles']['getPastWorkoutsForTodaysSplitDay']>;
 	};
-	let { todaysWorkoutData }: PropsType = $props();
+	let { todaysWorkoutData, pastWorkouts }: PropsType = $props();
 </script>
 
 <Card.Root>
@@ -37,7 +38,11 @@
 				<Card.Description>{wm?.mesocycle.name}</Card.Description>
 			</Card.Header>
 			<Card.Content>
-				<WorkoutProgressionChart workoutOfMesocycle={wm} />
+				{#await pastWorkouts}
+					<Skeleton class="h-40 w-full" />
+				{:then pastWorkouts}
+					<WorkoutProgressionChart {pastWorkouts} workoutOfMesocycle={wm} />
+				{/await}
 			</Card.Content>
 			<Card.Footer>
 				<Button class="ml-auto gap-2" href="/workouts/manage/start">

--- a/src/routes/(components)/page/TodaysWorkoutCard.svelte
+++ b/src/routes/(components)/page/TodaysWorkoutCard.svelte
@@ -10,7 +10,7 @@
 
 	type PropsType = {
 		todaysWorkoutData: Promise<RouterOutputs['workouts']['getTodaysWorkoutData']>;
-		pastWorkouts: Promise<RouterOutputs['mesocycles']['getPastWorkoutsForTodaysSplitDay']>;
+		pastWorkouts: Promise<RouterOutputs['mesocycles']['getWorkouts']>;
 	};
 	let { todaysWorkoutData, pastWorkouts }: PropsType = $props();
 </script>
@@ -46,7 +46,7 @@
 					{#await pastWorkouts}
 						<Skeleton class="h-40 w-full" />
 					{:then pastWorkouts}
-						<WorkoutProgressionChart {pastWorkouts} workoutOfMesocycle={wm} />
+						<WorkoutProgressionChart {pastWorkouts} />
 					{/await}
 				</Card.Content>
 			{/if}

--- a/src/routes/(components)/page/WorkoutProgressionChart.svelte
+++ b/src/routes/(components)/page/WorkoutProgressionChart.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+	import Skeleton from '$lib/components/ui/skeleton/skeleton.svelte';
 	import { trpc } from '$lib/trpc/client';
 	import type { RouterOutputs } from '$lib/trpc/router';
+	import { cn } from '$lib/utils';
 	import { getWorkoutVolume } from '$lib/utils/workoutUtils';
 	import {
 		CategoryScale,
@@ -59,6 +61,6 @@
 </script>
 
 {#if pastWorkouts === 'loading'}
-	TODO: chart skeleton
-{:else}{/if}
-<canvas bind:this={chartCanvas} class="h-20"></canvas>
+	<Skeleton class="h-40 w-full" />
+{/if}
+<canvas bind:this={chartCanvas} class={cn({ hidden: pastWorkouts === 'loading' })} height="160"></canvas>

--- a/src/routes/(components)/page/WorkoutProgressionChart.svelte
+++ b/src/routes/(components)/page/WorkoutProgressionChart.svelte
@@ -13,22 +13,23 @@
 		Title,
 		Tooltip
 	} from 'chart.js';
-	import { onMount } from 'svelte';
 	Chart.register(Tooltip, CategoryScale, LineController, LineElement, PointElement, Filler, LinearScale, Title, Legend);
 
 	type PropsType = { pastWorkouts: RouterOutputs['mesocycles']['getWorkouts'] };
 	let { pastWorkouts }: PropsType = $props();
 
+	let chart: Chart;
 	let chartCanvas: HTMLCanvasElement | undefined = $state();
 
-	onMount(async () => {
+	$effect(() => {
 		if (chartCanvas === undefined) return;
+		if (chart) chart.destroy();
 
 		const style = getComputedStyle(document.body);
 		const primaryColor = style.getPropertyValue('--primary').split(' ').join(', ');
 		const secondaryColor = style.getPropertyValue('--secondary').split(' ').join(', ');
 
-		new Chart(chartCanvas, {
+		chart = new Chart(chartCanvas, {
 			type: 'line',
 			data: {
 				labels: pastWorkouts.map((workout) =>

--- a/src/routes/(components)/page/WorkoutProgressionChart.svelte
+++ b/src/routes/(components)/page/WorkoutProgressionChart.svelte
@@ -16,16 +16,13 @@
 	import { onMount } from 'svelte';
 	Chart.register(Tooltip, CategoryScale, LineController, LineElement, PointElement, Filler, LinearScale, Title, Legend);
 
-	type PropsType = {
-		workoutOfMesocycle: RouterOutputs['workouts']['getTodaysWorkoutData']['workoutOfMesocycle'];
-		pastWorkouts: RouterOutputs['mesocycles']['getPastWorkoutsForTodaysSplitDay'];
-	};
-	let { workoutOfMesocycle, pastWorkouts }: PropsType = $props();
+	type PropsType = { pastWorkouts: RouterOutputs['mesocycles']['getWorkouts'] };
+	let { pastWorkouts }: PropsType = $props();
 
 	let chartCanvas: HTMLCanvasElement | undefined = $state();
 
 	onMount(async () => {
-		if (workoutOfMesocycle === undefined || chartCanvas === undefined) return;
+		if (chartCanvas === undefined) return;
 
 		const style = getComputedStyle(document.body);
 		const primaryColor = style.getPropertyValue('--primary').split(' ').join(', ');

--- a/src/routes/(components)/page/WorkoutProgressionChart.svelte
+++ b/src/routes/(components)/page/WorkoutProgressionChart.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-	import Skeleton from '$lib/components/ui/skeleton/skeleton.svelte';
-	import { trpc } from '$lib/trpc/client';
 	import type { RouterOutputs } from '$lib/trpc/router';
-	import { cn } from '$lib/utils';
 	import { getWorkoutVolume } from '$lib/utils/workoutUtils';
 	import {
 		CategoryScale,
@@ -12,26 +9,22 @@
 		LineController,
 		LineElement,
 		PointElement,
-		Tooltip,
-		Title
+		Title,
+		Tooltip
 	} from 'chart.js';
 	import { onMount } from 'svelte';
 	Chart.register(Tooltip, CategoryScale, LineController, LineElement, PointElement, Filler, LinearScale, Title);
 
-	type PropsType = { workoutOfMesocycle: RouterOutputs['workouts']['getTodaysWorkoutData']['workoutOfMesocycle'] };
-	let { workoutOfMesocycle }: PropsType = $props();
+	type PropsType = {
+		workoutOfMesocycle: RouterOutputs['workouts']['getTodaysWorkoutData']['workoutOfMesocycle'];
+		pastWorkouts: RouterOutputs['mesocycles']['getPastWorkoutsForTodaysSplitDay'];
+	};
+	let { workoutOfMesocycle, pastWorkouts }: PropsType = $props();
 
 	let chartCanvas: HTMLCanvasElement | undefined = $state();
-	let pastWorkouts: 'loading' | RouterOutputs['mesocycles']['getPastWorkouts'] = $state('loading');
 
 	onMount(async () => {
 		if (workoutOfMesocycle === undefined || chartCanvas === undefined) return;
-
-		// TODO: not ideal, should fetch during render, not after...
-		pastWorkouts = await trpc().mesocycles.getPastWorkouts.query({
-			mesocycleId: workoutOfMesocycle?.mesocycle.id,
-			splitDayIndex: workoutOfMesocycle?.splitDayIndex
-		});
 
 		const style = getComputedStyle(document.body);
 		const primaryColor = style.getPropertyValue('--primary').split(' ').join(', ');
@@ -60,7 +53,4 @@
 	});
 </script>
 
-{#if pastWorkouts === 'loading'}
-	<Skeleton class="h-40 w-full" />
-{/if}
-<canvas bind:this={chartCanvas} class={cn({ hidden: pastWorkouts === 'loading' })} height="160"></canvas>
+<canvas bind:this={chartCanvas} height="160"></canvas>

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -13,6 +13,6 @@ export const load = async (event) => {
 
 	return {
 		todaysWorkoutData: trpc.workouts.getTodaysWorkoutData(),
-		pastWorkouts: trpc.mesocycles.getPastWorkoutsForTodaysSplitDay()
+		pastWorkouts: trpc.mesocycles.getWorkouts('nextSplitDay')
 	};
 };

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -10,5 +10,9 @@ export const load = async (event) => {
 	}
 
 	const trpc = createCaller(await createContext(event));
-	return { todaysWorkoutData: trpc.workouts.getTodaysWorkoutData() };
+
+	return {
+		todaysWorkoutData: trpc.workouts.getTodaysWorkoutData(),
+		pastWorkouts: trpc.mesocycles.getPastWorkoutsForTodaysSplitDay()
+	};
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,5 +10,5 @@
 
 {#if data.todaysWorkoutData}
 	<H3>Today's workout</H3>
-	<TodaysWorkoutCard todaysWorkoutData={data.todaysWorkoutData} />
+	<TodaysWorkoutCard {...data} />
 {/if}

--- a/src/routes/exercise-splits/(components)/ExerciseSplitExercisesCharts.svelte
+++ b/src/routes/exercise-splits/(components)/ExerciseSplitExercisesCharts.svelte
@@ -122,6 +122,11 @@
 	});
 </script>
 
+<canvas
+	bind:this={chartCanvas}
+	class={cn('my-4 max-h-96', { 'max-h-56': selectedChartType.value === 'Bodyweight & weighted' })}
+></canvas>
+
 <Select.Root bind:selected={selectedChartType}>
 	<Select.Label class="mb-0.5 p-0">Chart type</Select.Label>
 	<Select.Trigger class="w-full">
@@ -133,8 +138,3 @@
 		{/each}
 	</Select.Content>
 </Select.Root>
-
-<canvas
-	bind:this={chartCanvas}
-	class={cn('my-4 max-h-96', { 'max-h-56': selectedChartType.value === 'Bodyweight & weighted' })}
-></canvas>

--- a/src/routes/mesocycles/[mesocycleId]/(components)/CustomRangeCalendar.svelte
+++ b/src/routes/mesocycles/[mesocycleId]/(components)/CustomRangeCalendar.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import { RangeCalendar as RangeCalendarPrimitive } from 'bits-ui';
+	import * as RangeCalendar from '$lib/components/ui/range-calendar/index';
+	import { cn } from '$lib/utils.js';
+	import CustomRangeCalendarDay from './CustomRangeCalendarDay.svelte';
+	import CheckIcon from 'virtual:icons/lucide/check';
+	import XIcon from 'virtual:icons/lucide/x';
+	import MoonIcon from 'virtual:icons/lucide/moon';
+	import type { DateValue } from '@internationalized/date';
+	import type { WorkoutStatus } from '@prisma/client';
+
+	type $$Props = RangeCalendarPrimitive.Props & { getDayStatus: (date: DateValue) => (WorkoutStatus | null)[] };
+
+	export let value: $$Props['value'] = undefined;
+	export let placeholder: $$Props['placeholder'] = undefined;
+	export let weekdayFormat: $$Props['weekdayFormat'] = 'short';
+	export let startValue: $$Props['startValue'] = undefined;
+	export let getDayStatus: $$Props['getDayStatus'];
+
+	let className: $$Props['class'] = undefined;
+	export { className as class };
+</script>
+
+<RangeCalendarPrimitive.Root
+	class={cn('p-3', className)}
+	{weekdayFormat}
+	on:keydown
+	bind:value
+	bind:placeholder
+	bind:startValue
+	{...$$restProps}
+	let:months
+	let:weekdays
+>
+	<RangeCalendar.Header>
+		<RangeCalendar.PrevButton />
+		<RangeCalendar.Heading />
+		<RangeCalendar.NextButton />
+	</RangeCalendar.Header>
+	<RangeCalendar.Months>
+		{#each months as month}
+			<RangeCalendar.Grid>
+				<RangeCalendar.GridHead>
+					<RangeCalendar.GridRow class="flex">
+						{#each weekdays as weekday}
+							<RangeCalendar.HeadCell class="w-10">
+								{weekday.slice(0, 2)}
+							</RangeCalendar.HeadCell>
+						{/each}
+					</RangeCalendar.GridRow>
+				</RangeCalendar.GridHead>
+				<RangeCalendar.GridBody>
+					{#each month.weeks as weekDates}
+						<RangeCalendar.GridRow class="mt-2 w-full">
+							{#each weekDates as date}
+								{@const dayStatus = getDayStatus(date)}
+								<RangeCalendar.Cell class="flex h-10 w-10 flex-col items-center justify-center" {date}>
+									<div class="flex h-5 w-full items-center justify-center gap-0.5">
+										{#each dayStatus as status}
+											{#if status === null}
+												<CheckIcon class="h-3 w-3" />
+											{:else if status === 'RestDay'}
+												<MoonIcon class="h-3 w-3" />
+											{:else}
+												<XIcon class="h-3 w-3" />
+											{/if}
+										{/each}
+									</div>
+									<CustomRangeCalendarDay
+										class={dayStatus.length === 0 ? 'text-muted-foreground' : ''}
+										{date}
+										month={month.value}
+									/>
+								</RangeCalendar.Cell>
+							{/each}
+						</RangeCalendar.GridRow>
+					{/each}
+				</RangeCalendar.GridBody>
+			</RangeCalendar.Grid>
+		{/each}
+	</RangeCalendar.Months>
+</RangeCalendarPrimitive.Root>

--- a/src/routes/mesocycles/[mesocycleId]/(components)/CustomRangeCalendarDay.svelte
+++ b/src/routes/mesocycles/[mesocycleId]/(components)/CustomRangeCalendarDay.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { RangeCalendar as RangeCalendarPrimitive } from 'bits-ui';
+	import { buttonVariants } from '$lib/components/ui/button/index.js';
+	import { cn } from '$lib/utils.js';
+
+	type $$Props = RangeCalendarPrimitive.DayProps;
+
+	export let date: $$Props['date'];
+	export let month: $$Props['month'];
+	let className: $$Props['class'] = undefined;
+	export { className as class };
+</script>
+
+<RangeCalendarPrimitive.Day
+	class={cn(
+		buttonVariants({ variant: 'ghost' }),
+		'h-9 w-9 p-0 font-normal data-[selected]:opacity-100',
+		'[&[data-today]:not([data-selected])]:bg-accent [&[data-today]:not([data-selected])]:text-accent-foreground',
+		// Outside months
+		'data-[outside-month]:pointer-events-none data-[outside-month]:text-muted-foreground data-[outside-month]:opacity-50 [&[data-outside-month][data-selected]]:bg-accent/50 [&[data-outside-month][data-selected]]:text-muted-foreground [&[data-outside-month][data-selected]]:opacity-30',
+		// Disabled
+		'data-[disabled]:text-muted-foreground data-[disabled]:opacity-50',
+		// Unavailable
+		'data-[unavailable]:text-destructive-foreground data-[unavailable]:line-through',
+		className
+	)}
+	{date}
+	{month}
+	on:click
+	{...$$restProps}
+	let:builder
+	let:disabled
+	let:unavailable
+>
+	<slot {builder} {disabled} {unavailable}>
+		{date.day}
+	</slot>
+</RangeCalendarPrimitive.Day>

--- a/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleBasicsTab.svelte
+++ b/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleBasicsTab.svelte
@@ -18,14 +18,14 @@
 
 	import LoaderCircle from 'virtual:icons/lucide/loader-circle';
 	import { arraySum } from '$lib/utils';
-	import type { FullMesocycle } from '../+layout.server';
 	import { trpc } from '$lib/trpc/client';
 	import { toast } from 'svelte-sonner';
 	import { goto, invalidate } from '$app/navigation';
 	import { mesocycleRunes, type FullMesocycleWithoutIds } from '../../manage/mesocycleRunes.svelte';
 	import { TRPCClientError } from '@trpc/client';
+	import type { RouterOutputs } from '$lib/trpc/router';
 
-	let { mesocycle }: { mesocycle: FullMesocycle } = $props();
+	let { mesocycle }: { mesocycle: NonNullable<RouterOutputs['mesocycles']['findById']> } = $props();
 	let deleteConfirmDrawerOpen = $state(false);
 	let extractSplitConfirmDrawerOpen = $state(false);
 	let extractedExerciseSplitName = $state('');
@@ -96,7 +96,9 @@
 	}
 
 	function convertMesocycleSplitDayExerciseToExerciseSplitDayExercise(
-		exercise: FullMesocycle['mesocycleExerciseSplitDays'][number]['mesocycleSplitDayExercises'][number]
+		exercise: NonNullable<
+			RouterOutputs['mesocycles']['findById']
+		>['mesocycleExerciseSplitDays'][number]['mesocycleSplitDayExercises'][number]
 	) {
 		const {
 			sets,

--- a/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleSplitTab.svelte
+++ b/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleSplitTab.svelte
@@ -3,17 +3,13 @@
 	import * as Card from '$lib/components/ui/card';
 	import * as Tabs from '$lib/components/ui/tabs';
 	import EditIcon from 'virtual:icons/lucide/pencil';
-	import type { FullMesocycle } from '../+layout.server';
 	import ExerciseTemplateCard from '$lib/components/mesocycleAndExerciseSplit/ExerciseTemplateCard.svelte';
 	import { mesocycleExerciseSplitRunes } from '../edit-split/mesocycleExerciseSplitRunes.svelte';
 	import { goto } from '$app/navigation';
+	import type { RouterOutputs } from '$lib/trpc/router';
 
-	type MesocycleSplitDay = FullMesocycle['mesocycleExerciseSplitDays'][number];
-	let { mesocycle }: { mesocycle: FullMesocycle } = $props();
-
-	let selectedSplitDay = $state(
-		mesocycle.mesocycleExerciseSplitDays.find((splitDay) => !splitDay.isRestDay) as MesocycleSplitDay
-	);
+	let { mesocycle }: { mesocycle: NonNullable<RouterOutputs['mesocycles']['findById']> } = $props();
+	let selectedSplitDay = $state(mesocycle.mesocycleExerciseSplitDays.find((splitDay) => !splitDay.isRestDay)!);
 
 	function editMesocycleExerciseSplit() {
 		mesocycleExerciseSplitRunes.loadExerciseSplit(mesocycle);
@@ -30,9 +26,7 @@
 <Tabs.Root
 	class="w-full"
 	onValueChange={(v) => {
-		selectedSplitDay = mesocycle.mesocycleExerciseSplitDays.find(
-			(splitDay) => splitDay.name === v
-		) as MesocycleSplitDay;
+		selectedSplitDay = mesocycle.mesocycleExerciseSplitDays.find((splitDay) => splitDay.name === v)!;
 	}}
 	value={selectedSplitDay.name}
 >

--- a/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleStats.svelte
+++ b/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleStats.svelte
@@ -6,7 +6,6 @@
 		generatePerformanceChangesPerSplitDay,
 		getSetsPerformedPerMuscleGroup
 	} from '$lib/utils/mesocycleUtils';
-	import type { FullMesocycle } from '../+layout.server';
 	import CircleCheck from 'virtual:icons/lucide/circle-check';
 	import CircleX from 'virtual:icons/lucide/circle-X';
 	import BicepsFlexed from 'virtual:icons/lucide/biceps-flexed';
@@ -15,8 +14,9 @@
 	import CalendarArrowDown from 'virtual:icons/lucide/calendar-arrow-down';
 	import ChartColumnIncreasing from 'virtual:icons/lucide/chart-column-increasing';
 	import ChartColumnDecreasing from 'virtual:icons/lucide/chart-column-decreasing';
+	import type { RouterOutputs } from '$lib/trpc/router';
 
-	let { mesocycle }: { mesocycle: FullMesocycle } = $props();
+	let { mesocycle }: { mesocycle: NonNullable<RouterOutputs['mesocycles']['findById']> } = $props();
 
 	const totalWorkoutsOfMesocycle = $derived(mesocycle.workoutsOfMesocycle.length);
 	const totalMesocycleLength = $derived(

--- a/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleVolumeTab.svelte
+++ b/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleVolumeTab.svelte
@@ -19,7 +19,7 @@
 				<Table.Head>Regardless of progress</Table.Head>
 			</Table.Row>
 		</Table.Header>
-		<Table.Body>
+		<Table.Body data-testid="mesocycle-volume-table-body">
 			{#each cyclicSetChanges as setChange}
 				<Table.Row>
 					<Table.Cell class="font-medium">

--- a/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleWorkoutsCharts.svelte
+++ b/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleWorkoutsCharts.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import * as Select from '$lib/components/ui/select';
+	import * as Card from '$lib/components/ui/card';
+	import type { Selected } from 'bits-ui';
+	import WorkoutProgressionChart from '../../../(components)/page/WorkoutProgressionChart.svelte';
+	import type { RouterOutputs } from '$lib/trpc/router';
+
+	let { mesocycle }: { mesocycle: NonNullable<RouterOutputs['mesocycles']['findById']> } = $props();
+
+	const firstNonRestDay = mesocycle.mesocycleExerciseSplitDays.find((splitDay) => !splitDay.isRestDay)!;
+	let selectedExerciseSplitDayIndex: Selected<number> = $state({
+		value: firstNonRestDay.dayIndex,
+		label: firstNonRestDay.name
+	});
+</script>
+
+<Card.Root class="p-4">
+	<WorkoutProgressionChart
+		pastWorkouts={mesocycle.workoutsOfMesocycle
+			.filter((wm) => wm.splitDayIndex === selectedExerciseSplitDayIndex.value)
+			.map((wm) => wm.workout)}
+	/>
+
+	<Select.Root bind:selected={selectedExerciseSplitDayIndex}>
+		<Select.Label class="pl-0">Split day name</Select.Label>
+		<Select.Trigger class="w-full">
+			<Select.Value />
+		</Select.Trigger>
+		<Select.Content>
+			{#each mesocycle.mesocycleExerciseSplitDays as splitDay}
+				<Select.Item disabled={splitDay.isRestDay} value={splitDay.dayIndex}>
+					{splitDay.isRestDay ? 'Rest' : splitDay.name}
+				</Select.Item>
+			{/each}
+		</Select.Content>
+	</Select.Root>
+</Card.Root>

--- a/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleWorkoutsTab.svelte
+++ b/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleWorkoutsTab.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { RangeCalendar } from '$lib/components/ui/range-calendar/index.js';
+	import { arraySum } from '$lib/utils';
+	import { getLocalTimeZone, isSameDay, parseDate, today, type DateValue } from '@internationalized/date';
+	import type { FullMesocycle } from '../+layout.server';
+
+	function dateToCalendarDate(date: Date | undefined) {
+		if (!date) date = new Date();
+		return parseDate(date.toISOString().slice(0, 10));
+	}
+
+	let { mesocycle }: { mesocycle: FullMesocycle } = $props();
+
+	const workoutStartDates = mesocycle.workoutsOfMesocycle.map((wm) => ({
+		date: dateToCalendarDate(wm.workout.startedAt),
+		workoutStatus: wm.workoutStatus
+	}));
+	const lastWorkoutDate = workoutStartDates.at(-1)!.date;
+	const startDate = workoutStartDates[0].date;
+
+	const completedMesocycleWorkouts = mesocycle.workoutsOfMesocycle.length;
+	const totalMesocycleWorkouts = mesocycle.mesocycleExerciseSplitDays.length * arraySum(mesocycle.RIRProgression);
+	const remainingMesocycleWorkouts = totalMesocycleWorkouts - completedMesocycleWorkouts;
+	const endDate = today(getLocalTimeZone()).add({ days: remainingMesocycleWorkouts });
+
+	function isDateUnavailable(date: DateValue) {
+		const isDateWithinMesocycleRange = lastWorkoutDate.compare(date) > 0 && date.compare(startDate) > 0;
+		if (!isDateWithinMesocycleRange) return false;
+
+		return !workoutStartDates.some(
+			({ date: startDate, workoutStatus }) => isSameDay(date, startDate) && workoutStatus === null
+		);
+	}
+</script>
+
+<RangeCalendar
+	class="w-fit rounded-md border"
+	isDateDisabled={(date) => lastWorkoutDate.compare(date) < 0}
+	isDateUnavailable={(date) => isDateUnavailable(date)}
+	maxValue={endDate}
+	minValue={startDate}
+	readonly
+	value={{ start: startDate, end: endDate }}
+/>

--- a/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleWorkoutsTab.svelte
+++ b/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleWorkoutsTab.svelte
@@ -3,15 +3,15 @@
 	import { arraySum } from '$lib/utils';
 	import { getLocalTimeZone, isSameDay, parseDate, today } from '@internationalized/date';
 	import type { DateRange } from 'bits-ui';
-	import type { FullMesocycle } from '../+layout.server';
 	import CustomRangeCalendar from './CustomRangeCalendar.svelte';
+	import type { RouterOutputs } from '$lib/trpc/router';
 
 	function dateToCalendarDate(date: Date | undefined) {
 		if (!date) date = new Date();
 		return parseDate(date.toISOString().slice(0, 10));
 	}
 
-	let { mesocycle }: { mesocycle: FullMesocycle } = $props();
+	let { mesocycle }: { mesocycle: NonNullable<RouterOutputs['mesocycles']['findById']> } = $props();
 
 	const workoutStartDates = mesocycle.workoutsOfMesocycle.map((wm) => ({
 		date: dateToCalendarDate(wm.workout.startedAt),

--- a/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleWorkoutsTab.svelte
+++ b/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleWorkoutsTab.svelte
@@ -65,8 +65,7 @@
 					})}
 				</span>
 				{#if workoutOfMesocycle}
-					{@const splitDayName =
-						mesocycle.mesocycleExerciseSplitDays[workoutOfMesocycle.splitDayIndex].name}
+					{@const splitDayName = mesocycle.mesocycleExerciseSplitDays[workoutOfMesocycle.splitDayIndex].name}
 					<span class="truncate text-muted-foreground">
 						{splitDayName === '' ? 'Rest' : splitDayName}
 						{workoutOfMesocycle.workoutStatus === 'Skipped' ? '(skipped)' : ''}

--- a/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleWorkoutsTab.svelte
+++ b/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleWorkoutsTab.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+	import { Button } from '$lib/components/ui/button';
 	import { arraySum } from '$lib/utils';
 	import { getLocalTimeZone, isSameDay, parseDate, today } from '@internationalized/date';
+	import type { DateRange } from 'bits-ui';
 	import type { FullMesocycle } from '../+layout.server';
 	import CustomRangeCalendar from './CustomRangeCalendar.svelte';
 
@@ -20,19 +22,57 @@
 	const completedMesocycleWorkouts = mesocycle.workoutsOfMesocycle.length;
 	const totalMesocycleWorkouts = mesocycle.mesocycleExerciseSplitDays.length * arraySum(mesocycle.RIRProgression);
 	const remainingMesocycleWorkouts = totalMesocycleWorkouts - completedMesocycleWorkouts;
-	const endDate = mesocycle.endDate ? workoutStartDates.at(-1)!.date : today(getLocalTimeZone()).add({ days: remainingMesocycleWorkouts });
+	const endDate = mesocycle.endDate
+		? workoutStartDates.at(-1)!.date
+		: today(getLocalTimeZone()).add({ days: remainingMesocycleWorkouts });
+
+	let dateRange: DateRange = $state({ start: startDate, end: endDate });
+	let filteredWorkoutsOfMesocycle = $derived(
+		mesocycle.workoutsOfMesocycle.filter((wm) => {
+			if (!dateRange.start || !dateRange.end) return;
+			const workoutDate = dateToCalendarDate(wm.workout.startedAt);
+			return workoutDate.compare(dateRange.start) >= 0 && workoutDate.compare(dateRange.end) <= 0;
+		})
+	);
 </script>
 
-<CustomRangeCalendar
-	class="w-fit rounded-md border"
-	getDayStatus={(date) => {
-		const workoutsOfMesocycleOnThisDay = mesocycle.workoutsOfMesocycle.filter((wm) => {
-			return isSameDay(dateToCalendarDate(wm.workout.startedAt), date);
-		});
-		return workoutsOfMesocycleOnThisDay.map((wm) => wm.workoutStatus);
-	}}
-	maxValue={endDate}
-	minValue={startDate}
-	readonly
-	value={{ start: startDate, end: endDate }}
-/>
+<div class="flex h-full flex-col gap-2">
+	<CustomRangeCalendar
+		class="mx-auto w-fit rounded-md border"
+		getDayStatus={(date) => {
+			const workoutsOfMesocycleOnThisDay = mesocycle.workoutsOfMesocycle.filter((wm) => {
+				return isSameDay(dateToCalendarDate(wm.workout.startedAt), date);
+			});
+			return workoutsOfMesocycleOnThisDay.map((wm) => wm.workoutStatus);
+		}}
+		maxValue={endDate}
+		minValue={startDate}
+		readonly
+		bind:value={dateRange}
+	/>
+
+	<div class="flex h-px grow flex-col gap-1 overflow-y-auto">
+		{#each filteredWorkoutsOfMesocycle as { workout, ...workoutOfMesocycle }}
+			<Button
+				class="flex h-12 items-center justify-between rounded-md border bg-card p-2"
+				href="/workouts/{workout.id}"
+				variant="outline"
+			>
+				<span class="text-lg font-semibold">
+					{workout.startedAt.toLocaleDateString(undefined, {
+						day: '2-digit',
+						month: 'long'
+					})}
+				</span>
+				{#if workoutOfMesocycle}
+					{@const splitDayName =
+						mesocycle.mesocycleExerciseSplitDays[workoutOfMesocycle.splitDayIndex].name}
+					<span class="truncate text-muted-foreground">
+						{splitDayName === '' ? 'Rest' : splitDayName}
+						{workoutOfMesocycle.workoutStatus === 'Skipped' ? '(skipped)' : ''}
+					</span>
+				{/if}
+			</Button>
+		{/each}
+	</div>
+</div>

--- a/src/routes/mesocycles/[mesocycleId]/+layout.server.ts
+++ b/src/routes/mesocycles/[mesocycleId]/+layout.server.ts
@@ -1,6 +1,5 @@
 import { createCaller } from '$lib/trpc/router';
 import { createContext } from '$lib/trpc/context';
-import { Prisma } from '@prisma/client';
 
 export const load = async (event) => {
 	event.depends(`mesocycles:${event.params.mesocycleId}`);
@@ -8,20 +7,3 @@ export const load = async (event) => {
 	const mesocycle = trpc.mesocycles.findById(event.params.mesocycleId);
 	return { mesocycle };
 };
-
-export type FullMesocycle = Prisma.MesocycleGetPayload<{
-	include: {
-		exerciseSplit: true;
-		mesocycleExerciseSplitDays: { include: { mesocycleSplitDayExercises: true } };
-		mesocycleCyclicSetChanges: true;
-		workoutsOfMesocycle: {
-			include: {
-				workout: {
-					include: {
-						workoutExercises: { include: { sets: { include: { miniSets: true } } } };
-					};
-				};
-			};
-		};
-	};
-}>;

--- a/src/routes/mesocycles/[mesocycleId]/+page.svelte
+++ b/src/routes/mesocycles/[mesocycleId]/+page.svelte
@@ -12,6 +12,7 @@
 	import MesocycleStats from './(components)/MesocycleStats.svelte';
 	import MesocycleVolumeTab from './(components)/MesocycleVolumeTab.svelte';
 	import type { FullMesocycle } from './+layout.server';
+	import MesocycleWorkoutsTab from './(components)/MesocycleWorkoutsTab.svelte';
 
 	let { data } = $props();
 	let mesocycle: FullMesocycle | 'loading' = $state('loading');
@@ -66,7 +67,7 @@
 		</Tabs.Content>
 		<Tabs.Content class="grow" value="workouts">
 			{#if !chartMode}
-				<MesocycleStats {mesocycle} />
+				<MesocycleWorkoutsTab {mesocycle} />
 			{:else}
 				TODO: charts that show progression
 			{/if}

--- a/src/routes/mesocycles/[mesocycleId]/+page.svelte
+++ b/src/routes/mesocycles/[mesocycleId]/+page.svelte
@@ -4,6 +4,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import * as Tabs from '$lib/components/ui/tabs';
 	import H2 from '$lib/components/ui/typography/H2.svelte';
+	import type { RouterOutputs } from '$lib/trpc/router';
 	import { onMount } from 'svelte';
 	import { toast } from 'svelte-sonner';
 	import MesocycleCyclicSetChangesCharts from '../(components)/MesocycleCyclicSetChangesCharts.svelte';
@@ -13,11 +14,11 @@
 	import MesocycleSplitTab from './(components)/MesocycleSplitTab.svelte';
 	import MesocycleStats from './(components)/MesocycleStats.svelte';
 	import MesocycleVolumeTab from './(components)/MesocycleVolumeTab.svelte';
+	import MesocycleWorkoutsCharts from './(components)/MesocycleWorkoutsCharts.svelte';
 	import MesocycleWorkoutsTab from './(components)/MesocycleWorkoutsTab.svelte';
-	import type { FullMesocycle } from './+layout.server';
 
 	let { data } = $props();
-	let mesocycle: FullMesocycle | 'loading' = $state('loading');
+	let mesocycle: NonNullable<RouterOutputs['mesocycles']['findById']> | 'loading' = $state('loading');
 	let selectedTabValue = $state('basics');
 	let chartMode = $state(false);
 	const completion = $page.url.searchParams.has('completion');
@@ -75,7 +76,7 @@
 			{#if !chartMode}
 				<MesocycleWorkoutsTab {mesocycle} />
 			{:else}
-				TODO: charts that show progression
+				<MesocycleWorkoutsCharts {mesocycle} />
 			{/if}
 		</Tabs.Content>
 	</Tabs.Root>

--- a/tests/models/mesocycles.spec.ts
+++ b/tests/models/mesocycles.spec.ts
@@ -42,8 +42,8 @@ test('create a mesocycle', async ({ page }) => {
 	);
 
 	await page.getByRole('tab', { name: 'Volume' }).click();
-	await expect(page.locator('tbody')).toContainText('50');
-	await expect(page.locator('tbody')).toContainText('2');
+	await expect(page.getByTestId('mesocycle-volume-table-body')).toContainText('50');
+	await expect(page.getByTestId('mesocycle-volume-table-body')).toContainText('2');
 });
 
 test('delete a mesocycle', async ({ page }) => {
@@ -106,8 +106,8 @@ test('edit a mesocycle', async ({ page }) => {
 		'RIR progression 10 cycles 3 2 1 0 Start exercise template Pull Push Legs Preferred progression variable Load Start overload percentage 1.25% Last set to failure Force RIR matching'
 	);
 	await page.getByRole('tab', { name: 'Volume' }).click();
-	await expect(page.locator('tbody')).toContainText('45');
-	await expect(page.locator('tbody')).toContainText('3');
+	await expect(page.getByTestId('mesocycle-volume-table-body')).toContainText('45');
+	await expect(page.getByTestId('mesocycle-volume-table-body')).toContainText('3');
 });
 
 test('start and stop a mesocycle', async ({ page }) => {

--- a/tests/models/workouts.spec.ts
+++ b/tests/models/workouts.spec.ts
@@ -40,8 +40,7 @@ test('create workout', async ({ page }) => {
 	);
 });
 
-test('create workout with all set types', async ({ page, browserName }) => {
-	test.skip(browserName === 'webkit', 'TODO: breaks for some reason, that too only in GHA CI/CD');
+test('create workout with all set types', async ({ page }) => {
 	await page.goto('/workouts');
 	await page.getByLabel('create-workout').click();
 	await page.getByPlaceholder('Type here').fill('100');


### PR DESCRIPTION
## Description
Fixes #67 

## Type of change
New feature (non-breaking change which adds functionality)

## Important for stable
- [x] workout progression chart skeleton
- [x] move workout progression chart's data fetching to +page.server.ts
- [x] mesocycle stats tab

## Not important for stable but later
- notifications for ongoing workouts
- view workouts exercises charts
- more exerciseSplits and exerciseTemplates

## Maybes
- add more browsers to playwright testing config (mobile browsers even)
- splitDayIndex changing when split day names move around

