### PR TITLE
fix: Various bug fixes for v3

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,13 +4,11 @@ import svelte from 'eslint-plugin-svelte';
 import prettier from 'eslint-config-prettier';
 import globals from 'globals';
 
-/** @type {import('eslint').Linter.FlatConfig[]} */
 export default [
 	{ ignores: ['.vercel/', '.svelte-kit/', 'postcss.config.cjs'] },
 	js.configs.recommended,
-	...ts.configs.recommended,
-	...svelte.configs['flat/all'],
 	prettier,
+	...ts.configs.recommended,
 	...svelte.configs['flat/prettier'],
 	{ languageOptions: { globals: { ...globals.browser, ...globals.node } } },
 	{
@@ -30,16 +28,7 @@ export default [
 					varsIgnorePattern: '^_',
 					ignoreRestSiblings: true
 				}
-			],
-			'svelte/no-at-html-tags': 'off',
-			'svelte/block-lang': ['error', { script: ['ts'], style: ['postcss'] }],
-			'svelte/experimental-require-strict-events': 'off',
-			'svelte/no-unused-class-name': 'off',
-			'svelte/no-goto-without-base': 'off',
-			'svelte/require-each-key': 'off',
-			'svelte/no-inline-styles': ['error', { allowTransitions: true }],
-			'svelte/prefer-destructured-store-props': 'off',
-			'svelte/experimental-require-slot-types': 'off'
+			]
 		}
 	},
 	{

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,7 @@ const config: PlaywrightTestConfig = {
 	globalSetup: './tests/global-setup',
 	globalTeardown: './tests/global-teardown',
 	workers: process.env.CI ? 1 : undefined,
-	reporter: 'list',
+	reporter: process.env.CI ? 'list' : 'html',
 	use: {
 		baseURL: 'http://localhost:4173',
 		trace: 'on-first-retry',

--- a/src/lib/trpc/routes/workouts.ts
+++ b/src/lib/trpc/routes/workouts.ts
@@ -303,7 +303,7 @@ export const workouts = t.router({
 		}
 
 		// Update mesocycle's exercise templates according to new workout
-		if (workoutOfMesocycle.workoutStatus === undefined) {
+		if (workoutOfMesocycle.workoutStatus === null) {
 			const todaysSplitDay = mesocycleData.mesocycleExerciseSplitDays[workoutOfMesocycle.splitDayIndex];
 			if (!todaysSplitDay) {
 				throw new TRPCError({ code: 'BAD_REQUEST', message: 'Related mesocycle exercise split day not found' });

--- a/src/lib/utils/workoutUtils.ts
+++ b/src/lib/utils/workoutUtils.ts
@@ -418,6 +418,15 @@ export function progressiveOverloadMagic(
 	});
 
 	// TODO: Add miniSets and stuff if drop / myorep match sets
+	workoutExercises.forEach((ex) => {
+		ex.sets.forEach((set) => {
+			set.miniSets = set.miniSets.map((miniSet) => {
+				const { id, ...rest } = miniSet;
+				return rest;
+			});
+		});
+	});
+
 	// TODO: Remaining overrides to implement: load first progression
 
 	return workoutExercises;

--- a/src/lib/utils/workoutUtils.ts
+++ b/src/lib/utils/workoutUtils.ts
@@ -420,16 +420,5 @@ export function progressiveOverloadMagic(
 	// TODO: Add miniSets and stuff if drop / myorep match sets
 	// TODO: Remaining overrides to implement: load first progression
 
-	const previousWorkout = workoutsOfMesocycle.filter((wm) => wm.workoutStatus === null).at(-1)?.workout;
-	const previousWorkoutData = previousWorkout
-		? {
-				exercises: previousWorkout.workoutExercises,
-				userBodyweight: previousWorkout.userBodyweight
-			}
-		: null;
-
-	return {
-		todaysWorkoutExercises: workoutExercises,
-		previousWorkoutData
-	};
+	return workoutExercises;
 }

--- a/src/routes/(components)/page/TodaysWorkoutCard.svelte
+++ b/src/routes/(components)/page/TodaysWorkoutCard.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import Badge from '$lib/components/ui/badge/badge.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import Skeleton from '$lib/components/ui/skeleton/skeleton.svelte';
 	import type { RouterOutputs } from '$lib/trpc/router';
 	import { getRIRForWeek } from '$lib/utils/workoutUtils';
+	import { workoutRunes } from '../../workouts/manage/workoutRunes.svelte';
 	import WorkoutProgressionChart from './WorkoutProgressionChart.svelte';
 	import ChevronRight from 'virtual:icons/lucide/chevron-right';
 
@@ -13,6 +15,11 @@
 		pastWorkouts: Promise<RouterOutputs['mesocycles']['getWorkouts']>;
 	};
 	let { todaysWorkoutData, pastWorkouts }: PropsType = $props();
+
+	function createNewWorkout() {
+		if (workoutRunes.editingWorkoutId !== null) workoutRunes.resetStores();
+		goto('/workouts/manage/start');
+	}
 </script>
 
 <Card.Root>
@@ -51,7 +58,7 @@
 				</Card.Content>
 			{/if}
 			<Card.Footer>
-				<Button class="ml-auto gap-2" href="/workouts/manage/start">
+				<Button class="ml-auto gap-2" onclick={createNewWorkout}>
 					Start
 					<ChevronRight />
 				</Button>

--- a/src/routes/workouts/manage/exercises/(components)/CompareComponent.svelte
+++ b/src/routes/workouts/manage/exercises/(components)/CompareComponent.svelte
@@ -18,6 +18,7 @@
 	function getTheoreticalVolumeChange(setIdx: number) {
 		const prevSet = prevExercise?.sets[setIdx];
 		if (!prevSet) return;
+		if (!exercise.sets[setIdx]) return;
 
 		let { reps, load, RIR } = exercise.sets[setIdx];
 		if (reps === undefined || load === undefined || RIR === undefined) return;

--- a/src/routes/workouts/manage/exercises/+page.server.ts
+++ b/src/routes/workouts/manage/exercises/+page.server.ts
@@ -15,7 +15,7 @@ export const load = async (event) => {
 	if (isNaN(splitDayIndex) || splitDayIndex < 0) error(400, 'Invalid split day index');
 
 	const trpc = createCaller(await createContext(event));
-	const serverData = trpc.workouts.getTodaysWorkoutExercises({
+	const serverData = trpc.workouts.getWorkoutExercisesWithPreviousData({
 		userBodyweight,
 		splitDayIndex
 	});

--- a/src/routes/workouts/manage/overview/+page.svelte
+++ b/src/routes/workouts/manage/overview/+page.svelte
@@ -11,6 +11,7 @@
 	import * as Tabs from '$lib/components/ui/tabs';
 	import ExerciseSplitExercisesCharts from '../../../exercise-splits/(components)/ExerciseSplitExercisesCharts.svelte';
 	import { TRPCClientError } from '@trpc/client';
+	import { mesocycleExerciseSplitRunes } from '../../../mesocycles/[mesocycleId]/edit-split/mesocycleExerciseSplitRunes.svelte';
 
 	let savingWorkout = $state(false);
 	let workoutExercises = $derived(workoutRunes.workoutExercises ?? []);
@@ -92,6 +93,12 @@
 			await invalidate('workouts:all');
 			await goto('/workouts');
 			workoutRunes.resetStores();
+
+			// Reset meso editing store as it won't change if workout affects meso split days and same mesocycle gets edited
+			// 1. User attempts active meso edit but doesn't complete it (stores save meso data)
+			// 2. User performs workouts affecting the meso split structure
+			// 3. User tries to update meso again, but sees old data as it didn't sync the new changes from workouts
+			mesocycleExerciseSplitRunes.resetStores();
 
 			if (mesocycleCompleted) {
 				await goto(`/mesocycles/${workoutRunes.workoutData.workoutOfMesocycle?.mesocycle.id}?completion`);

--- a/src/routes/workouts/manage/overview/+page.svelte
+++ b/src/routes/workouts/manage/overview/+page.svelte
@@ -98,6 +98,7 @@
 			// 1. User attempts active meso edit but doesn't complete it (stores save meso data)
 			// 2. User performs workouts affecting the meso split structure
 			// 3. User tries to update meso again, but sees old data as it didn't sync the new changes from workouts
+			// So to prevent this from happening, just reset the meso split runes after a workout is completed
 			mesocycleExerciseSplitRunes.resetStores();
 
 			if (mesocycleCompleted) {

--- a/src/routes/workouts/manage/workoutRunes.svelte.ts
+++ b/src/routes/workouts/manage/workoutRunes.svelte.ts
@@ -7,7 +7,7 @@ import {
 	createWorkoutExerciseInProgressFromMesocycleExerciseTemplate
 } from '$lib/utils/workoutUtils';
 
-type PreviousWorkoutData = RouterOutputs['workouts']['getTodaysWorkoutExercises']['previousWorkoutData'];
+type PreviousWorkoutData = RouterOutputs['workouts']['getWorkoutExercisesWithPreviousData']['previousWorkoutData'];
 
 function createWorkoutRunes() {
 	let workoutData: RouterOutputs['workouts']['getTodaysWorkoutData'] | null = $state(null);

--- a/src/routes/workouts/manage/workoutRunes.svelte.ts
+++ b/src/routes/workouts/manage/workoutRunes.svelte.ts
@@ -101,10 +101,10 @@ function createWorkoutRunes() {
 			exerciseToEdit.sets[i] = {
 				...historySet,
 				completed: false,
-				miniSets: historySet.miniSets.map((miniSet) => ({
-					...miniSet,
-					completed: false
-				}))
+				miniSets: historySet.miniSets.map((miniSet) => {
+					const { id, workoutExerciseSetId, ...restOfTheMiniSet } = miniSet;
+					return { ...restOfTheMiniSet, completed: false };
+				})
 			};
 		}
 

--- a/tests/models/mesocycles.spec.ts
+++ b/tests/models/mesocycles.spec.ts
@@ -46,10 +46,6 @@ test('create a mesocycle', async ({ page }) => {
 	await expect(page.getByTestId('mesocycle-volume-table-body')).toContainText('2');
 });
 
-test('workout modification should update the MesocycleExerciseSplitDay', async ({ page }) => {
-	// TODO
-})
-
 test('delete a mesocycle', async ({ page }) => {
 	await page.getByLabel('create-new-mesocycle').click();
 	await page.getByLabel('Mesocycle name').fill('MesoToDelete');

--- a/tests/models/mesocycles.spec.ts
+++ b/tests/models/mesocycles.spec.ts
@@ -46,6 +46,10 @@ test('create a mesocycle', async ({ page }) => {
 	await expect(page.getByTestId('mesocycle-volume-table-body')).toContainText('2');
 });
 
+test('workout modification should update the MesocycleExerciseSplitDay', async ({ page }) => {
+	// TODO
+})
+
 test('delete a mesocycle', async ({ page }) => {
 	await page.getByLabel('create-new-mesocycle').click();
 	await page.getByLabel('Mesocycle name').fill('MesoToDelete');

--- a/tests/models/workouts.spec.ts
+++ b/tests/models/workouts.spec.ts
@@ -336,3 +336,40 @@ test('edit a workout', async ({ page }) => {
 		'Pull-ups 3 Straight sets of 5 to 15 reps BW Lats Reps Load RIR 1 7 0 3 2 6 0 3 3 5 0 0'
 	);
 });
+
+test('workout changes should update mesocycle split', async ({ page }) => {
+	await createMesocycle(page, { exerciseSplitCreated: true });
+	await page.getByRole('link', { name: 'Workouts' }).click();
+	await page.getByPlaceholder('Type here').fill('100');
+	await page.getByRole('button', { name: 'Next' }).click();
+
+	await page.getByTestId('Barbell rows-menu-button').click();
+	await page.getByRole('menuitem', { name: 'Delete' }).click();
+	await page.getByTestId('Dumbbell bicep curls-menu-button').click();
+	await page.getByRole('menuitem', { name: 'Delete' }).click();
+	await page.getByTestId('Face pulls-menu-button').click();
+	await page.getByRole('menuitem', { name: 'Delete' }).click();
+
+	await page.locator('#Pull-ups-set-1-reps').fill('8');
+	await page.locator('#Pull-ups-set-2-reps').fill('7');
+	await page.locator('#Pull-ups-set-1-load').fill('0');
+	await page.getByTestId('Pull-ups-menu-button').click();
+	await page.getByRole('menuitem', { name: 'Edit' }).click();
+	await page.getByLabel('Sets').fill('2');
+	await page.getByPlaceholder('Exercise cues, machine').click();
+	await page.getByPlaceholder('Exercise cues, machine').fill('Custom note');
+	await page.getByRole('button', { name: 'Edit exercise' }).click();
+	await expect(page.getByRole('main')).toContainText('Custom note');
+
+	await page.getByTestId('Pull-ups-set-1-action').click();
+	await page.getByTestId('Pull-ups-set-2-action').click();
+	await page.getByRole('button', { name: 'Next' }).click();
+	await page.getByRole('button', { name: 'Save' }).click();
+
+	await page.getByRole('link', { name: 'Mesocycles' }).click();
+	await page.getByRole('link', { name: 'MyMeso Active' }).first().click();
+	await page.getByRole('tab', { name: 'Split' }).click();
+	await expect(page.getByRole('main')).toContainText(
+		'Pull APush ALegs APull BPush BLegs BRest Pull-ups 2 Straight sets of 5 to 15 reps BW Lats Custom note'
+	);
+});

--- a/tests/models/workouts.spec.ts
+++ b/tests/models/workouts.spec.ts
@@ -5,7 +5,7 @@ function getTodaysDateString() {
 	return new Date().toLocaleDateString(undefined, { month: 'long', day: '2-digit' });
 }
 
-async function createMesoForTest(page: Page) {
+async function createSplitAndMesoForTest(page: Page) {
 	await page.goto('/exercise-splits');
 	await createMesocycle(page);
 	await page.goto('/workouts');
@@ -162,7 +162,7 @@ test('create workout with all set types', async ({ page }) => {
 });
 
 test('create a workout with active mesocycle', async ({ page }) => {
-	await createMesoForTest(page);
+	await createSplitAndMesoForTest(page);
 	await page.getByLabel('create-workout').click();
 	await expect(page.getByRole('main')).toContainText('Pull A Day 1, Cycle 1 LatsTrapsBicepsRear delts');
 	await page.getByPlaceholder('Type here').click();
@@ -218,7 +218,7 @@ test('create a workout with active mesocycle', async ({ page }) => {
 });
 
 test('create workout without using active mesocycle', async ({ page }) => {
-	await createMesoForTest(page);
+	await createSplitAndMesoForTest(page);
 	await page.getByLabel('create-workout').click();
 	await page.getByLabel('Use active mesocycle').click();
 	await page.getByPlaceholder('Type here').click();
@@ -251,7 +251,7 @@ test('create workout without using active mesocycle', async ({ page }) => {
 });
 
 test('skip a workout', async ({ page }) => {
-	await createMesoForTest(page);
+	await createSplitAndMesoForTest(page);
 	await page.getByLabel('create-workout').click();
 	await page.getByPlaceholder('Type here').fill('100');
 	await page.getByRole('button', { name: 'Skip' }).click();
@@ -261,7 +261,7 @@ test('skip a workout', async ({ page }) => {
 });
 
 test('delete a workout', async ({ page }) => {
-	await createMesoForTest(page);
+	await createSplitAndMesoForTest(page);
 	await page.getByLabel('create-workout').click();
 	await page.getByPlaceholder('Type here').fill('100');
 	await page.getByRole('button', { name: 'Next' }).click();
@@ -292,14 +292,15 @@ test('delete a workout', async ({ page }) => {
 	await page.getByRole('button', { name: 'Yes, delete' }).click();
 	await expect(page.getByRole('status').filter({ hasText: 'Workout deleted successfully' })).toBeVisible();
 	await page.getByLabel('create-workout').click();
-	await expect(page.getByRole('main')).toContainText('Pull A Day 1, Cycle 1 LatsTrapsBicepsRear delts');
+	await expect(page.getByRole('main')).toContainText('Pull A Day 1, Cycle 1 Rear delts');
 });
 
 test('edit a workout', async ({ page }) => {
-	await createMesoForTest(page);
+	await createSplitAndMesoForTest(page);
 	await page.getByLabel('create-workout').click();
 	await page.getByPlaceholder('Type here').fill('100');
 	await page.getByRole('button', { name: 'Next' }).click();
+
 	await page.getByTestId('Barbell rows-menu-button').click();
 	await page.getByRole('menuitem', { name: 'Delete' }).click();
 	await page.getByTestId('Dumbbell bicep curls-menu-button').click();
@@ -338,8 +339,8 @@ test('edit a workout', async ({ page }) => {
 });
 
 test('workout changes should update mesocycle split', async ({ page }) => {
-	await createMesocycle(page, { exerciseSplitCreated: true });
-	await page.getByRole('link', { name: 'Workouts' }).click();
+	await createSplitAndMesoForTest(page);
+	await page.getByLabel('create-workout').click();
 	await page.getByPlaceholder('Type here').fill('100');
 	await page.getByRole('button', { name: 'Next' }).click();
 
@@ -365,6 +366,7 @@ test('workout changes should update mesocycle split', async ({ page }) => {
 	await page.getByTestId('Pull-ups-set-2-action').click();
 	await page.getByRole('button', { name: 'Next' }).click();
 	await page.getByRole('button', { name: 'Save' }).click();
+	await page.waitForURL('/workouts');
 
 	await page.getByRole('link', { name: 'Mesocycles' }).click();
 	await page.getByRole('link', { name: 'MyMeso Active' }).first().click();


### PR DESCRIPTION
## Description
A bunch of bugs in v3. Fixes: #78 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- `workouts.spec.ts > workout changes should update mesocycle split`

## Bugs to fix
- [x] exercise notes and sets not being updated after completing workouts
- [x] old reference workout being used in 2nd mesocycle (same name of splitDay)
- [x] IDs not being removed when copying miniSets from exercise history
- [x] load changeAmount and changeType not being updated correctly