### PR TITLE
Allow negative loads for bodyweight exercises

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ const config: PlaywrightTestConfig = {
 	retries: 2,
 	globalSetup: './tests/global-setup',
 	globalTeardown: './tests/global-teardown',
-	workers: process.env.CI ? 1 : undefined,
+	workers: process.env.CI ? 1 : '50%',
 	reporter: process.env.CI ? 'list' : 'html',
 	use: {
 		baseURL: 'http://localhost:4173',

--- a/src/routes/workouts/manage/exercises/(components)/SetsComponent.svelte
+++ b/src/routes/workouts/manage/exercises/(components)/SetsComponent.svelte
@@ -183,7 +183,7 @@
 					<Input
 						id="{exercise.name}-set-{idx + 1}-load"
 						disabled={set.completed || set.skipped}
-						min={0}
+						min={exercise.bodyweightFraction ? undefined : 0}
 						placeholder={getNextLoad(idx)}
 						required
 						step={0.25}
@@ -269,7 +269,7 @@
 							<Input
 								id="{exercise.name}-set-{idx + 1}-mini-set-{miniIdx + 1}-load"
 								disabled={miniSet.completed}
-								min={0}
+								min={exercise.bodyweightFraction ? undefined : 0}
 								placeholder={expectedLoad === undefined ? expectedLoad : expectedLoad.toString()}
 								required
 								step={0.25}


### PR DESCRIPTION
## Description
Exercises like Assisted pullups can have negative loads, this PR allows for that to happen. Fixes #91 

## Type of change
- Bug fix (non-breaking change which fixes an issue)