### PR TITLE
Prevent split structure change after mesocycle has workouts

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ const config: PlaywrightTestConfig = {
 	retries: 2,
 	globalSetup: './tests/global-setup',
 	globalTeardown: './tests/global-teardown',
-	workers: process.env.CI ? 1 : '50%',
+	workers: process.env.CI ? 1 : '25%',
 	reporter: process.env.CI ? 'list' : 'html',
 	use: {
 		baseURL: 'http://localhost:4173',

--- a/src/routes/mesocycles/[mesocycleId]/edit-split/mesocycleExerciseSplitRunes.svelte.ts
+++ b/src/routes/mesocycles/[mesocycleId]/edit-split/mesocycleExerciseSplitRunes.svelte.ts
@@ -1,4 +1,5 @@
 import type { MesocycleExerciseTemplateWithoutIdsOrIndex } from '$lib/components/mesocycleAndExerciseSplit/commonTypes';
+import type { RouterOutputs } from '$lib/trpc/router';
 import type { Prisma } from '@prisma/client';
 
 export type FullMesocycleWithExerciseSplit = Prisma.MesocycleGetPayload<{
@@ -11,7 +12,7 @@ type MesocycleExerciseSplitDayWithoutIds = Omit<
 >;
 
 export function createMesocycleExerciseSplitRunes() {
-	let mesocycle: FullMesocycleWithExerciseSplit | null = $state(null);
+	let mesocycle: RouterOutputs['mesocycles']['findById'] = $state(null);
 	let splitDays: MesocycleExerciseSplitDayWithoutIds[] = $state(
 		Array.from({ length: 7 }).map(() => ({ name: '', isRestDay: false }))
 	);
@@ -137,7 +138,7 @@ export function createMesocycleExerciseSplitRunes() {
 		saveStoresToLocalStorage();
 	}
 
-	function loadExerciseSplit(mesocycleWithExerciseSplit: FullMesocycleWithExerciseSplit) {
+	function loadExerciseSplit(mesocycleWithExerciseSplit: NonNullable<RouterOutputs['mesocycles']['findById']>) {
 		// Same mesocycle, don't reset and load new data, reuse and continue editing
 		if (mesocycleWithExerciseSplit.id === mesocycle?.id) return;
 

--- a/src/routes/mesocycles/[mesocycleId]/edit-split/structure/+page.svelte
+++ b/src/routes/mesocycles/[mesocycleId]/edit-split/structure/+page.svelte
@@ -58,7 +58,7 @@
 						>
 							<LockIcon class="h-4 w-4" />
 						</Popover.Trigger>
-						<Popover.Content class="w-60 text-sm" align="end">
+						<Popover.Content class="w-60 text-sm" align="start">
 							Cannot change the length or rest days of the mesocycle's exercise split after workouts have been added
 						</Popover.Content>
 					</Popover.Root>

--- a/tests/models/mesocycles.spec.ts
+++ b/tests/models/mesocycles.spec.ts
@@ -170,9 +170,47 @@ test("edit mesocycle's exercise split", async ({ page }) => {
 	await expect(page.getByRole('main')).toContainText('Face pulls 4 Straight sets of 15 to 30 reps Rear delts');
 });
 
+test('disallow exercise split editing after workout added', async ({ page }) => {
+	await createMesocycle(page, { exerciseSplitCreated: true });
+	await page.getByRole('link', { name: 'Workouts' }).click();
+	await page.getByLabel('create-workout').click();
+	await page.getByPlaceholder('Type here').fill('100');
+	await page.getByRole('button', { name: 'Next' }).click();
+	await page.getByTestId('Pull-ups-menu-button').click();
+	await page.getByRole('menuitem', { name: 'Delete' }).click();
+	await page.getByTestId('Barbell rows-menu-button').click();
+	await page.getByRole('menuitem', { name: 'Delete' }).click();
+	await page.getByTestId('Dumbbell bicep curls-menu-button').click();
+	await page.getByRole('menuitem', { name: 'Delete' }).click();
+
+	await page.locator('[id="Face\\ pulls-set-1-reps"]').fill('13');
+	await page.locator('[id="Face\\ pulls-set-2-reps"]').fill('11');
+	await page.locator('[id="Face\\ pulls-set-3-reps"]').fill('11');
+	await page.locator('[id="Face\\ pulls-set-1-load"]').fill('10');
+	await page.getByTestId('Face pulls-set-1-action').click();
+	await page.getByTestId('Face pulls-set-2-action').click();
+	await page.getByTestId('Face pulls-set-3-action').click();
+	await page.getByRole('button', { name: 'Next' }).click();
+	await page.getByRole('button', { name: 'Save' }).click();
+	await page.waitForURL('/workouts');
+
+	const lockedText =
+		"Cannot change the length or rest days of the mesocycle's exercise split after workouts have been added";
+	await page.getByRole('link', { name: 'Mesocycles' }).click();
+	await page.getByRole('link', { name: 'MyMeso Active' }).first().click();
+	await expect(page.getByRole('main')).toContainText(new Date().toLocaleDateString());
+	await page.getByRole('tab', { name: 'Split' }).click();
+	await page.getByRole('button', { name: 'Edit' }).click();
+	await page.getByLabel('mesocycle-exercise-split-edit').click();
+	await expect(page.getByText(lockedText)).toBeInViewport();
+	await expect(page.getByRole('button').filter({ hasText: 'Remove' })).toBeDisabled();
+	await expect(page.getByRole('button').filter({ hasText: 'Add' })).toBeDisabled();
+});
+
 test('extract exercise split from mesocycle', async ({ page }) => {
 	await createMesocycle(page, { exerciseSplitCreated: true });
 	await page.getByRole('link', { name: 'MyMeso' }).first().click();
+	await expect(page.getByRole('main')).toContainText(new Date().toLocaleDateString());
 	await page.getByRole('tab', { name: 'Split' }).click();
 	await page.getByRole('button', { name: 'Edit' }).click();
 	await page.getByRole('button', { name: 'Next' }).click();


### PR DESCRIPTION
## Description
Prevent split structure change after the mesocycle has workouts. Please also include relevant motivation and context. Fixes #87 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- `mesocycles.spec.ts > disallow exercise split editing after workout added`
