### PR TITLE
feat: Improve overloading algorithm

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -119,3 +119,17 @@ export function convertCamelCaseToNormal(text?: string | null): string {
 export function floorToNearestMultiple(number: number, multiple: number) {
 	return Math.floor(number / multiple) * multiple;
 }
+
+export function groupBy<T, K extends string | number | symbol>(array: T[], keyGetter: (item: T) => K): Record<K, T[]> {
+	return array.reduce(
+		(result: Record<K, T[]>, currentItem) => {
+			const key = keyGetter(currentItem);
+			if (!result[key]) {
+				result[key] = [];
+			}
+			result[key].push(currentItem);
+			return result;
+		},
+		{} as Record<K, T[]>
+	);
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -101,7 +101,7 @@ export function averagePercentageChange(arr: number[]): number {
 	const totalPercentageChange = arr.slice(1).reduce((sum, current, index) => {
 		const previous = arr[index];
 		const percentageChange = ((current - previous) / previous) * 100;
-		return sum + percentageChange;
+		return sum + (isNaN(percentageChange) ? 0 : percentageChange);
 	}, 0);
 
 	const numberOfIncrements = arr.length - 1;

--- a/src/lib/utils/workoutUtils.ts
+++ b/src/lib/utils/workoutUtils.ts
@@ -428,7 +428,7 @@ export function progressiveOverloadMagic(
 			if (set.reps === undefined) return;
 			if (RIRDifference > 0 && !(ex.forceRIRMatching ?? mesocycle.forceRIRMatching)) return;
 			if (set.reps - RIRDifference < ex.repRangeStart) {
-				const maxRIR = ex.repRangeStart - set.reps;
+				const maxRIR = Math.max(ex.repRangeStart - set.reps, 0);
 				set.RIR = maxRIR;
 				set.reps -= maxRIR - oldRIR;
 				return;

--- a/src/lib/utils/workoutUtils.ts
+++ b/src/lib/utils/workoutUtils.ts
@@ -421,6 +421,12 @@ export function progressiveOverloadMagic(
 			const RIRDifference = set.RIR - oldRIR;
 			if (set.reps === undefined) return;
 			if (RIRDifference > 0 && !(ex.forceRIRMatching ?? mesocycle.forceRIRMatching)) return;
+			if (set.reps - RIRDifference < ex.repRangeStart) {
+				const maxRIR = ex.repRangeStart - set.reps;
+				set.RIR = maxRIR;
+				set.reps -= maxRIR - oldRIR;
+				return;
+			}
 			set.reps -= RIRDifference;
 		});
 	});

--- a/src/lib/utils/workoutUtils.ts
+++ b/src/lib/utils/workoutUtils.ts
@@ -81,37 +81,6 @@ export function solveBergerFormula(input: BergerInput) {
 	}
 }
 
-// export function solveBryzckiFormula(input: BrzyckiInput) {
-// 	// #84
-// 	const { variableToSolve, knownValues } = input;
-// 	const {
-// 		oldSet,
-// 		newSet,
-// 		bodyweightFraction = null,
-// 		oldUserBodyweight = 0,
-// 		newUserBodyweight = 0,
-// 		overloadPercentage = 0
-// 	} = knownValues;
-
-// 	const oldLoad = oldSet.load + (bodyweightFraction ?? 0) * oldUserBodyweight;
-// 	const newLoad = newSet.load + (bodyweightFraction ?? 0) * newUserBodyweight;
-// 	const RHSConstants = 37 - newSet.RIR;
-
-// 	switch (variableToSolve) {
-// 		case 'NewReps': {
-// 			const numerator = newLoad * (oldSet.reps + oldSet.RIR - 37);
-// 			const denominator = (1 + overloadPercentage / 100) * oldLoad;
-// 			return numerator / denominator + RHSConstants;
-// 		}
-
-// 		case 'OverloadPercentage': {
-// 			const numerator = newLoad * (oldSet.reps + oldSet.RIR - 37);
-// 			const denominator = oldLoad * (knownValues.newSet.reps + newSet.RIR - 37);
-// 			return (numerator / denominator - 1) * 100;
-// 		}
-// 	}
-// }
-
 export function getWorkoutVolume(workout: Workout) {
 	return arraySum(workout.workoutExercises.map((exercise) => getExerciseVolume(exercise, workout.userBodyweight)));
 }

--- a/src/lib/utils/workoutUtils.ts
+++ b/src/lib/utils/workoutUtils.ts
@@ -201,7 +201,7 @@ function getPerformanceChanges(performances: { exercise: WorkoutExercise; oldUse
 			const oldSet = oldPerformance.exercise.sets[j];
 			const newSet = newPerformance.exercise.sets[j];
 			if (!oldSet || !newSet) break;
-			if (oldSet.skipped || newSet.skipped) break;
+			if (oldSet.skipped || newSet.skipped) continue;
 
 			setPerformanceChanges.push(
 				solveBergerFormula({

--- a/src/lib/utils/workoutUtils.ts
+++ b/src/lib/utils/workoutUtils.ts
@@ -154,6 +154,7 @@ export function getRIRForWeek(rirArray: number[], cycle: number): number {
 
 function generateAveragePerformanceDropOffs(performances: PreviousPerformance[]) {
 	const rateOfChangeSums: number[] = [];
+	let invalidDropOffs = false;
 
 	for (const performance of performances) {
 		for (let i = 0; i < performance.exercise.sets.length - 1; i++) {
@@ -169,7 +170,15 @@ function generateAveragePerformanceDropOffs(performances: PreviousPerformance[])
 					performance.exercise.bodyweightFraction
 				);
 			rateOfChangeSums[i] = (rateOfChangeSums[i] || 0) + rateOfChange;
+			if (rateOfChange < 0) {
+				invalidDropOffs = true;
+			}
 		}
+	}
+
+	// Incorrect RIR estimates causing an increase in set performance over time
+	if (invalidDropOffs) {
+		return new Array(rateOfChangeSums.length).fill(0);
 	}
 
 	const averageRatesOfChange = rateOfChangeSums.map((sum) => sum / performances.length);

--- a/src/lib/utils/workoutUtils.ts
+++ b/src/lib/utils/workoutUtils.ts
@@ -413,8 +413,6 @@ export function progressiveOverloadMagic(
 				setsToIncrease = Math.min(setsToIncrease, cyclicSetChange.setIncreaseAmount);
 			}
 
-			console.log(muscleGroup, averageMuscleGroupPerformanceChanges);
-
 			for (let i = 0; i < setsToIncrease; i++) {
 				const exercisesSortedBySets = exercises.sort((a, b) => a.sets.length - b.sets.length);
 				exercisesSortedBySets[0].sets.push({

--- a/src/lib/utils/workoutUtils.ts
+++ b/src/lib/utils/workoutUtils.ts
@@ -256,7 +256,12 @@ function increaseLoadOfSets(ex: WorkoutExerciseInProgress, userBodyweight: numbe
 
 	const newSets = ex.sets.map((set) => {
 		if (set.reps === undefined || set.load === undefined || set.RIR === undefined) return set;
-		const newLoad = set.load + (ex.minimumWeightChange ?? 5);
+
+		let newLoad = set.load;
+		if ((['Straight', 'Myorep'].includes(ex.setType) && needLoadIncrease) || set.reps > ex.repRangeStart) {
+			newLoad += ex.minimumWeightChange ?? 5;
+		}
+
 		const newReps = solveBergerFormula({
 			variableToSolve: 'NewReps',
 			knownValues: {
@@ -272,9 +277,10 @@ function increaseLoadOfSets(ex: WorkoutExerciseInProgress, userBodyweight: numbe
 		return newSet;
 	});
 
-	const goingBelowLowerRepRange = newSets.some((set) => set.reps! < ex.repRangeStart);
-	if (goingBelowLowerRepRange) return ex.sets;
-	return newSets;
+	return newSets.map((newSet, setIdx) => {
+		if (newSet.reps! < ex.repRangeStart) return ex.sets[setIdx];
+		return newSet;
+	});
 }
 
 function increaseSets(

--- a/src/lib/utils/workoutUtils.ts
+++ b/src/lib/utils/workoutUtils.ts
@@ -67,7 +67,7 @@ export function solveBergerFormula(input: BergerInput) {
 
 	switch (variableToSolve) {
 		case 'NewReps': {
-			const numerator = overloadPercentage * (9745640 * oldLoad - 423641) * exponentialMultiplier;
+			const numerator = (1 + overloadPercentage / 100) * (9745640 * oldLoad - 423641) * exponentialMultiplier;
 			const denominator = 9745640 * newLoad - 423641;
 			return 38.1679 * Math.log(numerator / denominator) - newSet.RIR;
 		}
@@ -253,6 +253,7 @@ function getPerformanceChanges(performances: { exercise: WorkoutExercise; oldUse
 }
 
 function adjustIdealPerformance(actualPerformances: number[], idealPerformance: number) {
+	if (actualPerformances.length < 2) return idealPerformance;
 	const weights = actualPerformances.map((_, index) => index + 1);
 	const weightedSum = actualPerformances.reduce((acc, performance, index) => {
 		return acc + performance * weights[index];

--- a/src/lib/utils/workoutUtils.ts
+++ b/src/lib/utils/workoutUtils.ts
@@ -9,7 +9,12 @@ export function getSetVolume(
 	userBodyweight: number,
 	bodyweightFraction: number | null
 ) {
-	return (set.reps + set.RIR) * set.load + (bodyweightFraction ?? 0) * userBodyweight;
+	const setVolume = (set.reps + set.RIR) * set.load + (bodyweightFraction ?? 0) * userBodyweight;
+	const miniSetsVolume = set.miniSets.reduce((totalMiniSetVolume, miniSet) => {
+		const miniSetVolume = (miniSet.reps + miniSet.RIR) * miniSet.load + (bodyweightFraction ?? 0) * userBodyweight;
+		return miniSetVolume + totalMiniSetVolume;
+	}, 0);
+	return setVolume + miniSetsVolume;
 }
 
 export function getExerciseVolume(workoutExercise: WorkoutExercise, userBodyweight: number) {

--- a/src/lib/utils/workoutUtils.ts
+++ b/src/lib/utils/workoutUtils.ts
@@ -300,7 +300,7 @@ function increaseSets(
 
 	const muscleGroup = exercise.customMuscleGroup ?? exercise.targetMuscleGroup;
 	const cyclicSetsForMuscleGroup = cyclicSetsPerMuscleGroup.get(muscleGroup) ?? 0;
-	if (cyclicSetsForMuscleGroup > cyclicSetChange.maxVolume) return exercise.sets;
+	if (cyclicSetsForMuscleGroup >= cyclicSetChange.maxVolume) return exercise.sets;
 
 	let setsToIncrease = 1;
 	if (performanceChanges.length > 0) {
@@ -313,7 +313,7 @@ function increaseSets(
 
 	return [
 		...exercise.sets,
-		...Array.from({ length: setsToIncrease }).map((_) => ({
+		...Array.from({ length: setsToIncrease }).map(() => ({
 			reps: undefined,
 			load: undefined,
 			RIR: undefined,
@@ -403,12 +403,14 @@ export function progressiveOverloadMagic(
 			}
 
 			ex.sets = increaseLoadOfSets(ex, userBodyweight);
-			ex.sets = increaseSets(
-				mesocycleWithProgressionData,
-				ex,
-				performanceChanges,
-				adjustedTotalOverloadPercentagePerSet
-			);
+			if (workoutsOfMesocycle.length >= 2) {
+				ex.sets = increaseSets(
+					mesocycleWithProgressionData,
+					ex,
+					performanceChanges,
+					adjustedTotalOverloadPercentagePerSet
+				);
+			}
 		});
 	}
 

--- a/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleBasicsTab.svelte
+++ b/src/routes/mesocycles/[mesocycleId]/(components)/MesocycleBasicsTab.svelte
@@ -259,7 +259,9 @@
 </Card.Root>
 
 <ResponsiveDialog title="Delete mesocycle?" bind:open={deleteConfirmDrawerOpen}>
-	<p>This action cannot be undone.</p>
+	{#snippet description()}
+		This action cannot be undone.
+	{/snippet}
 	<Button class="gap-2" disabled={callingDeleteEndpoint} onclick={deleteMesocycle} variant="destructive">
 		{#if callingDeleteEndpoint}
 			<LoaderCircle class="animate-spin" />

--- a/src/routes/workouts/[workoutId]/(components)/WorkoutExerciseCard.svelte
+++ b/src/routes/workouts/[workoutId]/(components)/WorkoutExerciseCard.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { Badge } from '$lib/components/ui/badge';
-	import MiniSetIcon from 'virtual:icons/lucide/arrow-down-right';
-	import { convertCamelCaseToNormal } from '$lib/utils';
 	import * as Table from '$lib/components/ui/table';
+	import { convertCamelCaseToNormal } from '$lib/utils';
 	import type { Prisma } from '@prisma/client';
+	import MiniSetIcon from 'virtual:icons/lucide/arrow-down-right';
 
 	type PropsType = {
 		exercise: Prisma.WorkoutExerciseGetPayload<{
@@ -50,9 +50,15 @@
 			{#each exercise.sets as set}
 				<Table.Row class="border-none">
 					<Table.Cell class="px-1 py-1.5 font-medium">{set.setIndex + 1}</Table.Cell>
-					<Table.Cell class="px-1 py-1.5 text-center font-light">{set.reps}</Table.Cell>
-					<Table.Cell class="px-1 py-1.5 text-center font-light">{set.load}</Table.Cell>
-					<Table.Cell class="px-1 py-1.5 text-center font-light">{set.RIR}</Table.Cell>
+					{#if !set.skipped}
+						<Table.Cell class="px-1 py-1.5 text-center font-light">{set.reps}</Table.Cell>
+						<Table.Cell class="px-1 py-1.5 text-center font-light">{set.load}</Table.Cell>
+						<Table.Cell class="px-1 py-1.5 text-center font-light">{set.RIR}</Table.Cell>
+					{:else}
+						<Table.Cell colspan={3} class="px-1 py-1.5 text-center italic text-muted-foreground">
+							<span>skipped</span>
+						</Table.Cell>
+					{/if}
 				</Table.Row>
 				{#each set.miniSets as miniSet}
 					<Table.Row class="border-none bg-muted/50">

--- a/src/routes/workouts/manage/exercises/(components)/CompareComponent.svelte
+++ b/src/routes/workouts/manage/exercises/(components)/CompareComponent.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { solveBrzyckiFormula, type WorkoutExerciseInProgress } from '$lib/utils/workoutUtils';
+	import { solveBergerFormula, type WorkoutExerciseInProgress } from '$lib/utils/workoutUtils';
 	import * as Popover from '$lib/components/ui/popover';
 	import { workoutRunes } from '../../workoutRunes.svelte';
 	import TrendUpIcon from 'virtual:icons/lucide/trending-up';
@@ -23,7 +23,7 @@
 		let { reps, load, RIR } = exercise.sets[setIdx];
 		if (reps === undefined || load === undefined || RIR === undefined) return;
 
-		const actualOverload = solveBrzyckiFormula({
+		const actualOverload = solveBergerFormula({
 			variableToSolve: 'OverloadPercentage',
 			knownValues: {
 				oldSet: prevSet,

--- a/src/routes/workouts/manage/exercises/(components)/CompareComponent.svelte
+++ b/src/routes/workouts/manage/exercises/(components)/CompareComponent.svelte
@@ -19,6 +19,7 @@
 		const prevSet = prevExercise?.sets[setIdx];
 		if (!prevSet) return;
 		if (!exercise.sets[setIdx]) return;
+		if (exercise.sets[setIdx].skipped || prevSet.skipped) return;
 
 		let { reps, load, RIR } = exercise.sets[setIdx];
 		if (reps === undefined || load === undefined || RIR === undefined) return;
@@ -78,27 +79,28 @@
 			{/if}
 		</span>
 		{#each exercise.sets as set, idx}
-			{#if prevExercise.sets[idx] && !set.skipped}
+			{@const prevSet = prevExercise.sets[idx]}
+			{#if prevSet && !prevSet.skipped && !set.skipped}
 				{@const volumeChange = getTheoreticalVolumeChange(idx)}
 				<p>
-					{#if prevExercise.sets[idx].reps !== set.reps}
-						<span class="text-muted-foreground">{prevExercise.sets[idx].reps} -&gt;</span>
+					{#if prevSet.reps !== set.reps}
+						<span class="text-muted-foreground">{prevSet.reps} -&gt;</span>
 						{set.reps}
 					{:else}
 						{set.reps}
 					{/if}
 				</p>
 				<p>
-					{#if prevExercise.sets[idx].load !== set.load}
-						<span class="text-muted-foreground">{prevExercise.sets[idx].load} -&gt;</span>
+					{#if prevSet.load !== set.load}
+						<span class="text-muted-foreground">{prevSet.load} -&gt;</span>
 						{set.load}
 					{:else}
 						{set.load}
 					{/if}
 				</p>
 				<p>
-					{#if prevExercise.sets[idx].RIR !== set.RIR}
-						<span class="text-muted-foreground">{prevExercise.sets[idx].RIR} -&gt;</span>
+					{#if prevSet.RIR !== set.RIR}
+						<span class="text-muted-foreground">{prevSet.RIR} -&gt;</span>
 						{set.RIR}
 					{:else}
 						{set.RIR}
@@ -119,9 +121,11 @@
 				<!-- #85 -->
 			{:else}
 				<Separator />
-				<span class="text-sm text-muted-foreground">
+				<span class="text-center text-sm text-muted-foreground">
 					{#if set.skipped}
 						skipped
+					{:else if prevSet?.skipped}
+						skipped last time
 					{:else}
 						new set
 					{/if}

--- a/src/routes/workouts/manage/exercises/(components)/SetsComponent.svelte
+++ b/src/routes/workouts/manage/exercises/(components)/SetsComponent.svelte
@@ -2,7 +2,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Separator } from '$lib/components/ui/separator';
-	import { solveBrzyckiFormula, type WorkoutExerciseInProgress } from '$lib/utils/workoutUtils';
+	import { solveBergerFormula, type WorkoutExerciseInProgress } from '$lib/utils/workoutUtils';
 	import CheckIcon from 'virtual:icons/lucide/check';
 	import RemoveIcon from 'virtual:icons/lucide/minus';
 	import EditIcon from 'virtual:icons/lucide/pencil';
@@ -108,7 +108,7 @@
 		if (!isSameLoadExercise) {
 			if (exerciseSet.reps === undefined || exerciseSet.RIR === undefined) return;
 			const newReps = Math.round(
-				solveBrzyckiFormula({
+				solveBergerFormula({
 					variableToSolve: 'NewReps',
 					knownValues: {
 						oldSet: { reps: exerciseSet.reps, load: oldLoad, RIR: exerciseSet.RIR },
@@ -128,7 +128,7 @@
 			if (set.reps === undefined || set.RIR === undefined) return;
 
 			const newReps = Math.round(
-				solveBrzyckiFormula({
+				solveBergerFormula({
 					variableToSolve: 'NewReps',
 					knownValues: {
 						oldSet: { reps: set.reps, load: oldLoad, RIR: set.RIR },
@@ -141,7 +141,7 @@
 				})
 			);
 
-			extraOverloadAchieved += solveBrzyckiFormula({
+			extraOverloadAchieved += solveBergerFormula({
 				variableToSolve: 'OverloadPercentage',
 				knownValues: {
 					oldSet: { reps: set.reps, load: oldLoad, RIR: set.RIR },

--- a/src/routes/workouts/manage/exercises/(components)/SetsComponent.svelte
+++ b/src/routes/workouts/manage/exercises/(components)/SetsComponent.svelte
@@ -183,7 +183,7 @@
 					<Input
 						id="{exercise.name}-set-{idx + 1}-load"
 						disabled={set.completed || set.skipped}
-						min={exercise.bodyweightFraction ? undefined : 0}
+						min={exercise.bodyweightFraction ? undefined : 0.25}
 						placeholder={getNextLoad(idx)}
 						required
 						step={0.25}

--- a/src/routes/workouts/manage/overview/+page.svelte
+++ b/src/routes/workouts/manage/overview/+page.svelte
@@ -91,9 +91,7 @@
 			}
 			toast.success(message);
 			await invalidate('workouts:all');
-			await goto('/workouts');
 			workoutRunes.resetStores();
-
 			// Reset meso editing store as it won't change if workout affects meso split days and same mesocycle gets edited
 			// 1. User attempts active meso edit but doesn't complete it (stores save meso data)
 			// 2. User performs workouts affecting the meso split structure
@@ -103,6 +101,8 @@
 
 			if (mesocycleCompleted) {
 				await goto(`/mesocycles/${workoutRunes.workoutData.workoutOfMesocycle?.mesocycle.id}?completion`);
+			} else {
+				await goto('/workouts');
 			}
 		} catch (error) {
 			if (error instanceof TRPCClientError) toast.error(error.message);


### PR DESCRIPTION
## Description
Make some changes to the overloading algorithm to improve rep suggestions and set increases.
Fixes #93, #90, #84, #106

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- `test_file.spec.ts > should_do_task_1`
- `test_file.spec.ts > should_do_task_2`

## Tasks
- [x] Replace the Brzycki formula with the Berger formula
- [x] Better load increase criteria (make repRangeEnd a soft limit and lower repRangeStart a hard limit)
- [x] Don't increase sets or reps for Cycle 2, can overdo progression easily
- [x] Don't add sets if already reached max volume for the specified muscle group for that microcycle
- [x] Distribute new sets evenly across exercises
- [x] Use (reps + RIR) * load for average drop-off calculation
- [x] Include mini sets in volume calculation
