### PR TITLE
feat: Mini set comparison and volume inclusion

### DIFF
--- a/src/lib/utils/workoutUtils.ts
+++ b/src/lib/utils/workoutUtils.ts
@@ -23,7 +23,7 @@ export type SetDetails = {
 	reps: number;
 	load: number;
 	RIR: number;
-	miniSets?: {
+	miniSets: {
 		reps: number;
 		load: number;
 		RIR: number;
@@ -35,20 +35,20 @@ type CommonBergerType = {
 	oldUserBodyweight?: number;
 	newUserBodyweight?: number;
 	overloadPercentage?: number;
-	oldSet: SetDetails;
+	oldSet: Omit<SetDetails, 'miniSets'>;
 };
 
 type BergerNewReps = {
 	variableToSolve: 'NewReps';
 	knownValues: CommonBergerType & {
-		newSet: Omit<SetDetails, 'reps'> & { reps?: number };
+		newSet: Omit<SetDetails, 'reps' | 'miniSets'> & { reps?: number };
 	};
 };
 
 type BergerOverloadPercentage = {
 	variableToSolve: 'OverloadPercentage';
 	knownValues: CommonBergerType & {
-		newSet: SetDetails;
+		newSet: Omit<SetDetails, 'miniSets'>;
 	};
 };
 

--- a/src/routes/workouts/manage/exercises/(components)/CompareComponent.svelte
+++ b/src/routes/workouts/manage/exercises/(components)/CompareComponent.svelte
@@ -53,11 +53,11 @@
 	}
 
 	type InProgressSet = { reps?: number; load?: number; RIR?: number; completed: boolean };
-	type CompletedSet = { reps: number; load: number; RIR: number; completed: true };
+	type CompletedSet = { reps: number; load: number; RIR: number; completed: boolean };
 
 	function isSetCompleted(miniSet: InProgressSet): miniSet is CompletedSet {
-		const { reps, load, RIR, completed } = miniSet;
-		return reps !== undefined && load !== undefined && RIR !== undefined && completed;
+		const { reps, load, RIR } = miniSet;
+		return reps !== undefined && load !== undefined && RIR !== undefined;
 	}
 
 	function getTheoreticalVolumeChangeOfMiniSet(prev: Omit<CompletedSet, 'completed'>, current: InProgressSet) {
@@ -98,7 +98,7 @@
 		</span>
 		<span class="text-sm font-medium">RIR</span>
 		<span class="flex w-full items-center justify-end gap-1 text-sm font-semibold">
-			{#if totalVolumeChange !== undefined}
+			{#if !isNaN(Number(totalVolumeChange)) && totalVolumeChange !== undefined}
 				{totalVolumeChange.toFixed(2)}%
 				{#if totalVolumeChange < 0}
 					<TrendDownIcon class="justify-self-end" />

--- a/src/routes/workouts/manage/exercises/(components)/CompareComponent.svelte
+++ b/src/routes/workouts/manage/exercises/(components)/CompareComponent.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
-	import { solveBergerFormula, type WorkoutExerciseInProgress } from '$lib/utils/workoutUtils';
 	import * as Popover from '$lib/components/ui/popover';
-	import { workoutRunes } from '../../workoutRunes.svelte';
-	import TrendUpIcon from 'virtual:icons/lucide/trending-up';
-	import UpIcon from 'virtual:icons/lucide/chevron-up';
-	import TrendDownIcon from 'virtual:icons/lucide/trending-down';
-	import DownIcon from 'virtual:icons/lucide/chevron-down';
-	import Minus from 'virtual:icons/lucide/minus';
 	import Separator from '$lib/components/ui/separator/separator.svelte';
 	import { arrayAverage } from '$lib/utils';
+	import {
+		cleanupInProgressMiniSets,
+		solveBergerFormula,
+		type WorkoutExerciseInProgress
+	} from '$lib/utils/workoutUtils';
+	import DownIcon from 'virtual:icons/lucide/chevron-down';
+	import UpIcon from 'virtual:icons/lucide/chevron-up';
+	import Minus from 'virtual:icons/lucide/minus';
+	import TrendDownIcon from 'virtual:icons/lucide/trending-down';
+	import TrendUpIcon from 'virtual:icons/lucide/trending-up';
+	import { workoutRunes } from '../../workoutRunes.svelte';
 
 	type PropsType = { exercise: WorkoutExerciseInProgress };
 	let { exercise }: PropsType = $props();
@@ -17,23 +21,26 @@
 
 	function getTheoreticalVolumeChange(setIdx: number) {
 		const prevSet = prevExercise?.sets[setIdx];
-		if (!prevSet) return;
-		if (!exercise.sets[setIdx]) return;
-		if (exercise.sets[setIdx].skipped || prevSet.skipped) return;
+		const currentSet = exercise.sets[setIdx];
 
-		let { reps, load, RIR } = exercise.sets[setIdx];
-		if (reps === undefined || load === undefined || RIR === undefined) return;
+		if (!prevSet) return;
+		if (!currentSet) return;
+		if (currentSet.skipped || prevSet.skipped) return;
+
+		if (!isSetCompleted(currentSet)) return;
+		let { reps, load, RIR, miniSets } = currentSet;
 
 		const actualOverload = solveBergerFormula({
 			variableToSolve: 'OverloadPercentage',
 			knownValues: {
 				oldSet: prevSet,
-				newSet: { reps, load, RIR },
+				newSet: { reps, load, RIR, miniSets: cleanupInProgressMiniSets(miniSets) },
 				newUserBodyweight: workoutRunes.workoutData?.userBodyweight as number,
 				oldUserBodyweight: workoutRunes.previousWorkoutData?.userBodyweight,
 				bodyweightFraction: exercise.bodyweightFraction ?? null
 			}
 		});
+		console.log(actualOverload);
 
 		return actualOverload;
 	}
@@ -43,6 +50,30 @@
 		return arrayAverage(
 			prevExercise.sets.map((_, idx) => getTheoreticalVolumeChange(idx)).filter((v) => v !== undefined)
 		);
+	}
+
+	type InProgressSet = { reps?: number; load?: number; RIR?: number; completed: boolean };
+	type CompletedSet = { reps: number; load: number; RIR: number; completed: true };
+
+	function isSetCompleted(miniSet: InProgressSet): miniSet is CompletedSet {
+		const { reps, load, RIR, completed } = miniSet;
+		return reps !== undefined && load !== undefined && RIR !== undefined && completed;
+	}
+
+	function getTheoreticalVolumeChangeOfMiniSet(prev: Omit<CompletedSet, 'completed'>, current: InProgressSet) {
+		if (!isSetCompleted(current)) return;
+
+		const actualOverload = solveBergerFormula({
+			variableToSolve: 'OverloadPercentage',
+			knownValues: {
+				oldSet: { ...prev, miniSets: [] },
+				newSet: { ...current, miniSets: [] },
+				newUserBodyweight: workoutRunes.workoutData?.userBodyweight as number,
+				oldUserBodyweight: workoutRunes.previousWorkoutData?.userBodyweight,
+				bodyweightFraction: exercise.bodyweightFraction ?? null
+			}
+		});
+		return actualOverload;
 	}
 
 	let totalVolumeChange = $derived(getAverageVolumeChangeOfAllSets());
@@ -85,26 +116,20 @@
 				<p>
 					{#if prevSet.reps !== set.reps}
 						<span class="text-muted-foreground">{prevSet.reps} -&gt;</span>
-						{set.reps}
-					{:else}
-						{set.reps}
 					{/if}
+					{set.reps}
 				</p>
 				<p>
 					{#if prevSet.load !== set.load}
 						<span class="text-muted-foreground">{prevSet.load} -&gt;</span>
-						{set.load}
-					{:else}
-						{set.load}
 					{/if}
+					{set.load}
 				</p>
 				<p>
 					{#if prevSet.RIR !== set.RIR}
 						<span class="text-muted-foreground">{prevSet.RIR} -&gt;</span>
-						{set.RIR}
-					{:else}
-						{set.RIR}
 					{/if}
+					{set.RIR}
 				</p>
 				<span class="flex w-full items-center justify-end gap-1 text-sm font-light">
 					{#if typeof volumeChange === 'number'}
@@ -118,7 +143,47 @@
 						{/if}
 					{/if}
 				</span>
-				<!-- TODO: #85 -->
+				{#each set.miniSets as miniSet, miniSetIdx}
+					{@const prevMiniSet = prevExercise.sets[idx].miniSets[miniSetIdx]}
+					{@const miniSetVolumeChange = getTheoreticalVolumeChangeOfMiniSet(prevMiniSet, miniSet)}
+					{#if prevMiniSet}
+						<p class="text-sm font-light italic">
+							{#if prevMiniSet.reps !== miniSet.reps}
+								<span class="text-muted-foreground">{prevMiniSet.reps} -&gt;</span>
+							{/if}
+							{miniSet.reps}
+						</p>
+						<p class="text-sm font-light italic">
+							{#if prevMiniSet.load !== miniSet.load}
+								<span class="text-muted-foreground">{prevMiniSet.load} -&gt;</span>
+							{/if}
+							{miniSet.load}
+						</p>
+						<p class="text-sm font-light italic">
+							{#if prevMiniSet.RIR !== miniSet.RIR}
+								<span class="text-muted-foreground">{prevMiniSet.RIR} -&gt;</span>
+							{/if}
+							{miniSet.RIR}
+						</p>
+						<span class="flex w-full items-center justify-end gap-1 text-xs font-light italic">
+							{#if typeof miniSetVolumeChange === 'number'}
+								<span>{miniSetVolumeChange?.toFixed(2)}%</span>
+								{#if miniSetVolumeChange < 0}
+									<DownIcon class="justify-self-end" />
+								{:else if miniSetVolumeChange > 0}
+									<UpIcon class="justify-self-end" />
+								{:else}
+									<Minus class="justify-self-end" />
+								{/if}
+							{/if}
+						</span>
+					{:else}
+						<Separator />
+						<span class="text-center text-sm text-muted-foreground">new mini set</span>
+						<Separator />
+						<span></span>
+					{/if}
+				{/each}
 			{:else}
 				<Separator />
 				<span class="text-center text-sm text-muted-foreground">

--- a/src/routes/workouts/manage/exercises/(components)/SetsComponent.svelte
+++ b/src/routes/workouts/manage/exercises/(components)/SetsComponent.svelte
@@ -2,7 +2,11 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import { Separator } from '$lib/components/ui/separator';
-	import { solveBergerFormula, type WorkoutExerciseInProgress } from '$lib/utils/workoutUtils';
+	import {
+		cleanupInProgressMiniSets,
+		solveBergerFormula,
+		type WorkoutExerciseInProgress
+	} from '$lib/utils/workoutUtils';
 	import CheckIcon from 'virtual:icons/lucide/check';
 	import RemoveIcon from 'virtual:icons/lucide/minus';
 	import EditIcon from 'virtual:icons/lucide/pencil';
@@ -111,11 +115,17 @@
 				solveBergerFormula({
 					variableToSolve: 'NewReps',
 					knownValues: {
-						oldSet: { reps: exerciseSet.reps, load: oldLoad, RIR: exerciseSet.RIR },
-						newSet: { load: newLoad, RIR: exerciseSet.RIR },
+						oldSet: {
+							reps: exerciseSet.reps,
+							load: oldLoad,
+							RIR: exerciseSet.RIR,
+							miniSets: cleanupInProgressMiniSets(exerciseSet.miniSets)
+						},
+						newSet: { load: newLoad, RIR: exerciseSet.RIR, miniSets: cleanupInProgressMiniSets(exerciseSet.miniSets) },
 						oldUserBodyweight: workoutRunes.previousWorkoutData?.userBodyweight,
 						newUserBodyweight: workoutRunes.workoutData?.userBodyweight as number,
-						bodyweightFraction: exercise.bodyweightFraction ?? null
+						bodyweightFraction: exercise.bodyweightFraction ?? null,
+						overloadPercentage: 0
 					}
 				})
 			);
@@ -131,8 +141,8 @@
 				solveBergerFormula({
 					variableToSolve: 'NewReps',
 					knownValues: {
-						oldSet: { reps: set.reps, load: oldLoad, RIR: set.RIR },
-						newSet: { load: newLoad, RIR: set.RIR },
+						oldSet: { reps: set.reps, load: oldLoad, RIR: set.RIR, miniSets: cleanupInProgressMiniSets(set.miniSets) },
+						newSet: { load: newLoad, RIR: set.RIR, miniSets: cleanupInProgressMiniSets(set.miniSets) },
 						oldUserBodyweight: workoutRunes.previousWorkoutData?.userBodyweight,
 						newUserBodyweight: workoutRunes.workoutData?.userBodyweight as number,
 						bodyweightFraction: exercise.bodyweightFraction ?? null,
@@ -144,8 +154,8 @@
 			extraOverloadAchieved += solveBergerFormula({
 				variableToSolve: 'OverloadPercentage',
 				knownValues: {
-					oldSet: { reps: set.reps, load: oldLoad, RIR: set.RIR },
-					newSet: { reps: newReps, load: newLoad, RIR: set.RIR },
+					oldSet: { reps: set.reps, load: oldLoad, RIR: set.RIR, miniSets: cleanupInProgressMiniSets(set.miniSets) },
+					newSet: { reps: newReps, load: newLoad, RIR: set.RIR, miniSets: cleanupInProgressMiniSets(set.miniSets) },
 					oldUserBodyweight: workoutRunes.previousWorkoutData?.userBodyweight,
 					newUserBodyweight: workoutRunes.workoutData?.userBodyweight as number,
 					bodyweightFraction: exercise.bodyweightFraction ?? null

--- a/src/routes/workouts/manage/overview/+page.svelte
+++ b/src/routes/workouts/manage/overview/+page.svelte
@@ -129,7 +129,7 @@
 				}}
 			/>
 		{:else}
-			<span class="muted-textbox">No previous workout available to compare</span>
+			<div class="muted-text-box">No previous workout available to compare</div>
 		{/if}
 	</Tabs.Content>
 	<Tabs.Content class="rounded-md border bg-card p-4" value="basic">


### PR DESCRIPTION
## Description
Include mini-set volume for exercises and show them in comparison component. Fixes #85 

## Type of change
- New feature (non-breaking change which adds functionality)

## Things to fix
- [x] Using the compare action button during workouts doesn't show mini-sets
- [x] Set volume doesn't consider mini-sets
- [x] Set types which rely on mini-sets might not progress as expected
